### PR TITLE
Bygg image med GITHUB_PAT

### DIFF
--- a/.github/workflows/harbor.yaml
+++ b/.github/workflows/harbor.yaml
@@ -56,3 +56,4 @@ jobs:
           push: ${{ github.event_name == 'release' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: GH_PAT=${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM rapporteket/base-r:main
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
-LABEL no.rapporteket.cd.enable="true"
+
+ARG GH_PAT
+ENV GITHUB_PAT=${GH_PAT}
 
 WORKDIR /app/R
 


### PR DESCRIPTION
For å unngå byggekrasj på grunn av api-kall-grense til Github